### PR TITLE
Add workflow to fetch Fortinet CVRF data

### DIFF
--- a/.github/workflows/update_cvrf.yml
+++ b/.github/workflows/update_cvrf.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
         with:
-          commit_message: chore: update CVRF data
-          file_pattern: cvrf/**
+           commit_message: "chore: update CVRF data"
+           file_pattern: "cvrf/**"

--- a/.github/workflows/update_cvrf.yml
+++ b/.github/workflows/update_cvrf.yml
@@ -1,0 +1,33 @@
+name: update-cvrf
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Set up Python
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install requests xmltodict
+      - name: Update CVRF data
+        run: python scripts/update_cvrf.py
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
+        with:
+          commit_message: chore: update CVRF data
+          file_pattern: cvrf/**

--- a/scripts/update_cvrf.py
+++ b/scripts/update_cvrf.py
@@ -10,9 +10,13 @@ FEED_URL = "https://filestore.fortinet.com/fortiguard/rss/ir.xml"
 
 
 def main():
-    resp = requests.get(FEED_URL, timeout=30)
-    resp.raise_for_status()
-    root = ET.fromstring(resp.content)
+    try:  
+        resp = requests.get(FEED_URL, timeout=30)  
+        resp.raise_for_status()  
+        root = ET.fromstring(resp.content)  
+    except (requests.RequestException, ET.ParseError) as e:  
+        print(f"Failed to fetch or parse feed {FEED_URL}: {e}")  
+        return 
 
     for item in root.findall('.//item'):
         link = item.findtext('link')
@@ -31,15 +35,23 @@ def main():
             continue
 
         cvrf_url = f"https://fortiguard.fortinet.com/psirt/cvrf/{vuln_id}"
-        cvrf_resp = requests.get(cvrf_url, timeout=30)
-        if cvrf_resp.status_code != 200:
-            print(f"Failed to fetch {cvrf_url}: {cvrf_resp.status_code}")
-            continue
-        data = xmltodict.parse(cvrf_resp.content)
-        os.makedirs(out_dir, exist_ok=True)
-        with open(out_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2)
-        print(f"Saved {out_path}")
+        cvrf_resp = requests.get(cvrf_url, headers={"Accept": "application/xml"}, timeout=30)  
+        if cvrf_resp.status_code != 200:  
+            print(f"Failed to fetch {cvrf_url}: {cvrf_resp.status_code}")  
+            continue  
+        try:  
+            data = xmltodict.parse(cvrf_resp.text)  
+        except Exception as e:  
+            print(f"Failed to parse XML for {cvrf_url}: {e}")  
+            continue  
+        os.makedirs(out_dir, exist_ok=True)  
+        try:  
+            with open(out_path, "w", encoding="utf-8") as f:  
+                json.dump(data, f, indent=2, ensure_ascii=False, sort_keys=True)  
+        except OSError as e:  
+            print(f"Failed to write {out_path}: {e}")  
+            continue  
+        print(f"Saved {out_path}")  
 
 
 if __name__ == "__main__":

--- a/scripts/update_cvrf.py
+++ b/scripts/update_cvrf.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import os
+import json
+import datetime
+import requests
+import xml.etree.ElementTree as ET
+import xmltodict
+
+FEED_URL = "https://filestore.fortinet.com/fortiguard/rss/ir.xml"
+
+
+def main():
+    resp = requests.get(FEED_URL, timeout=30)
+    resp.raise_for_status()
+    root = ET.fromstring(resp.content)
+
+    for item in root.findall('.//item'):
+        link = item.findtext('link')
+        pub_date = item.findtext('pubDate')
+        if not link or not pub_date:
+            continue
+        try:
+            year = datetime.datetime.strptime(pub_date, "%a, %d %b %Y %H:%M:%S %z").year
+        except ValueError:
+            year = "unknown"
+        vuln_id = link.rstrip('/').split('/')[-1]
+        out_dir = os.path.join("cvrf", str(year))
+        out_path = os.path.join(out_dir, f"{vuln_id}.json")
+        if os.path.exists(out_path):
+            print(f"Skipping {vuln_id}, already exists")
+            continue
+
+        cvrf_url = f"https://fortiguard.fortinet.com/psirt/cvrf/{vuln_id}"
+        cvrf_resp = requests.get(cvrf_url, timeout=30)
+        if cvrf_resp.status_code != 200:
+            print(f"Failed to fetch {cvrf_url}: {cvrf_resp.status_code}")
+            continue
+        data = xmltodict.parse(cvrf_resp.content)
+        os.makedirs(out_dir, exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- schedule workflow to download Fortinet CVRF advisories and commit JSON files by year
- add Python script to parse the Fortinet RSS feed and save CVRF data into year-based directories, skipping files that already exist

## Testing
- `go test ./...`
- `pip install requests xmltodict`
- `python scripts/update_cvrf.py` (run twice to confirm existing files are skipped)


------
https://chatgpt.com/codex/tasks/task_e_689f62083998832895aa40c569f12e13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically aggregates and saves the latest Fortinet CVRF security advisories as user-friendly JSON files, skipping already-stored items and continuing on partial failures.

* **Chores**
  * Added a scheduled job to refresh CVRF data daily (with manual trigger option) and automatically commits updates to keep advisory data current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->