### PR TITLE
feat: add product version subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A command line utility for parsing vendor bulletins in CVRF format. 
 
-Currently there is only a Fortinet module that processes Fortinet's RSS feed for new advisories and allows for the user to filter by CVSS score and/or product types to display vulnerabilites of interest. 
+Currently there is only a Fortinet module that processes Fortinet's RSS feed for new advisories and allows the user to filter by CVSS score and/or product types to display vulnerabilities of interest or check whether specific product versions are affected.
 
 
 ## Install
@@ -20,28 +20,38 @@ go install github.com/jakewarren/cvrf-review@latest
 ## Usage
 
 ```
-❯ cvrf-review fortinet -h
-Get Fortinet vulnerabilities
+❯ cvrf-review -h
+Review CVRF formmated vulnerability data
 
 Usage:
-  cvrf-review fortinet [flags]
+  cvrf-review [flags]
+  cvrf-review [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  fortinet    Get Fortinet vulnerabilities
+  help        Help about any command
 
 Flags:
-  -p, --product-types stringArray   Filter vulnerabilities by product type. Must match the value provided by Fortinet in the CVRF data. Examples: 'FortiOS', 'FortiClientEMS'
-
-Global Flags:
       --disable-border         Disable the table border
   -h, --help                   Print usage
       --json                   Print output in JSON format
       --max-cvss-score float   Filter vulnerabilities by a maximum CVSS score (default 10)
       --min-cvss-score float   Filter vulnerabilities by a minimum CVSS score
   -s, --severity string        Filter vulnerabilities by severity (critical, high, medium, low)
+
+Use "cvrf-review [command] --help" for more information about a command.
 ```
 
 ### Examples:
 
 #### Get critical Fortinet vulnerabilities:
 ![screenshot](docs/images/fortinet_critical.png)
+
+#### List vulnerabilities for a specific product version
+```bash
+cvrf-review fortinet affected --product FortiOS --version 6.4.10
+```
 
 ## Acknowledgments
 Inspired by [MaineK00n/vuls-data-update](https://github.com/MaineK00n/vuls-data-update).

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+func TestProductVulnerabilities(t *testing.T) {
+	tests := []struct {
+		name    string
+		product string
+		version string
+		cve     string
+		want    bool
+	}{
+		{
+			name:    "FortiClientEMS 7.2.2 has CVE-2023-48788",
+			product: "FortiClientEMS",
+			version: "7.2.2",
+			cve:     "CVE-2023-48788",
+			want:    true,
+		},
+		{
+			name:    "FortiClientEMS 7.2.3 lacks CVE-2023-48788",
+			product: "FortiClientEMS",
+			version: "7.2.3",
+			cve:     "CVE-2023-48788",
+			want:    false,
+		},
+		{
+			name:    "FortiOS 6.4.10 has CVE-2022-42475",
+			product: "FortiOS",
+			version: "6.4.10",
+			cve:     "CVE-2022-42475",
+			want:    true,
+		},
+		{
+			name:    "FortiOS 6.4.11 lacks CVE-2022-42475",
+			product: "FortiOS",
+			version: "6.4.11",
+			cve:     "CVE-2022-42475",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			advisories, err := getAffectedAdvisories(tt.product, tt.version)
+			if err != nil {
+				t.Fatalf("failed to load advisories: %v", err)
+			}
+
+			found := false
+			for _, a := range advisories {
+				for _, cve := range a.Vulnerability.CVE {
+					if cve == tt.cve {
+						found = true
+						break
+					}
+				}
+				if found {
+					break
+				}
+			}
+
+			if found != tt.want {
+				t.Fatalf("CVE %s affected=%v, want %v", tt.cve, found, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/fortinet/fortinet.go
+++ b/pkg/fortinet/fortinet.go
@@ -25,7 +25,9 @@ func getRssEntries() (RSS, error) {
 		return RSS{}, errors.New("status is not ok. got response code: " + resp.Status)
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	var rss RSS
 	if err = xml.NewDecoder(resp.Body).Decode(&rss); err != nil {
@@ -51,7 +53,9 @@ func getCVRFData(advisoryID string) (CVRF, error) {
 	if err != nil {
 		return CVRF{}, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return CVRF{}, errors.New("status is not ok. got response code: " + resp.Status)


### PR DESCRIPTION
## Summary
- walk cached Fortinet CVRF JSON to list vulnerabilities for a specific product version
- normalize CVRF reference parsing to handle single or multiple entries
- verify FortiClientEMS 7.2.2 maps to CVE-2023-48788 using cached data
- exercise table-driven tests covering FortiOS and FortiClientEMS mappings
- document `fortinet affected` usage and root CLI help in README using `cvrf-review` binary
- ensure HTTP responses are properly closed and unused helper removed

## Testing
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a65fad361083289f9bf1efc0cb910c