### PR TITLE
Ensure affected command emits complete CVRF JSON

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/charmbracelet/lipgloss v0.9.1
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/cobra v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=

--- a/pkg/fortinet/fortinet.go
+++ b/pkg/fortinet/fortinet.go
@@ -37,8 +37,8 @@ func getRssEntries() (RSS, error) {
 	return rss, nil
 }
 
-// getCVRFData fetches the CVRF data for a given advisory ID
-func getCVRFData(advisoryID string) (CVRF, error) {
+// GetCVRFData fetches the CVRF data for a given advisory ID
+func GetCVRFData(advisoryID string) (CVRF, error) {
 	client := &http.Client{
 		Timeout: time.Second * 10,
 	}
@@ -85,7 +85,7 @@ func GetAdvisories() ([]CVRF, error) {
 		advisoryID := path.Base(u.Path)
 
 		// get the CVRF data for each vulnerability
-		cvrf, err := getCVRFData(advisoryID)
+		cvrf, err := GetCVRFData(advisoryID)
 		if err != nil {
 			fmt.Printf("error getting CVRF data for %s: %s\n", entry.Link, err)
 			return nil, err


### PR DESCRIPTION
## Summary
- normalize cached Fortinet CVRF JSON and decode into full advisory objects
- export helper to fetch CVRF data directly
- add mapstructure dependency

## Testing
- `go test ./...`
- `go run . fortinet affected --product FortiOS --version 6.4.2 -s critical --json | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_68a9e9fe2484832880197841f0e8778d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed a public API to fetch CVRF data by advisory ID, enabling easier integration.
* **Bug Fixes**
  * More reliable parsing of varied CVRF formats, including product IDs, CVE lists, references, acknowledgments, and CVSS scores.
  * Improved validation and error handling for malformed or incomplete documents.
* **Refactor**
  * Reworked CVRF parsing to a normalization-and-decode pipeline for greater robustness and consistency.
* **Chores**
  * Added a decoding dependency to support flexible data mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->