### PR TITLE
Pretty print fortinet affected output

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,9 +115,7 @@ var fortinetVersionCmd = &cobra.Command{
 			fmt.Println(string(j))
 		} else {
 			for _, a := range matchingAdvisories {
-				for _, cve := range a.Vulnerability.CVE {
-					fmt.Printf("%s - %s\n", cve, a.DocumentTitle)
-				}
+				printCVRF(a)
 			}
 		}
 	},


### PR DESCRIPTION
## Summary
- format `go run . fortinet affected` output with the same table presentation as `fortinet`

## Testing
- `go test ./...`
- `go run . fortinet affected --product FortiOS --version 6.4.10 | head`


------
https://chatgpt.com/codex/tasks/task_e_68a9fd3b666c83288a010139b2ce4e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Non-JSON output now shows a structured CVRF table per advisory, providing richer details (title, ID, release date, link, CVSS, notes, affected products, etc.) instead of per-CVE lines.

- Refactor
  - Consolidated advisory printing to a single, consistent presentation path for improved readability. No changes to JSON output or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->