### PR TITLE
Fix WASM execution script path and enhance advisory output formatting

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           mkdir site
           cp index.html main.js styles.css site/
-          cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" site/
+          cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" site/
           cp -r cvrf site/
           cp -r docs site/
           GOOS=js GOARCH=wasm go build -o site/main.wasm .

--- a/main.go
+++ b/main.go
@@ -116,7 +116,11 @@ var fortinetVersionCmd = &cobra.Command{
 		}
 
 		if len(matchingAdvisories) == 0 {
-			fmt.Println("No matching advisories found.")
+			if jsonOutput {
+				fmt.Println("[]")
+			} else {
+				fmt.Println("No matching advisories found.")
+			}
 			return
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON output now correctly returns an empty array when no matching advisories are found, ensuring valid JSON responses.
  * Non-JSON output continues to display a clear message when no advisories are found.

* **Chores**
  * Updated site build workflow to use the correct WebAssembly runtime file path, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->