### PR TITLE
ci: trigger pages after update workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,10 @@
 name: github-pages
 
 on:
-  push:
-    branches: [master]
+  workflow_run:
+    workflows: ["update-fortinet-cvrf"]
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -12,6 +14,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- run pages workflow after update-fortinet-cvrf completes
- allow manual pages deployment

## Testing
- `golangci-lint run`
- `go test -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c0a49771e88328badcab848d427ca7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to run after a successful upstream update process or via manual trigger, replacing push-based triggers.
  * Added safeguards to prevent deployments when the upstream workflow fails, reducing unnecessary or erroneous runs.
  * Improves stability and predictability of releases without changing application behavior.
  * Build steps and environment remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->