### PR TITLE
ci: trigger pages after update workflow and push

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,10 @@ name: github-pages
 on:
   push:
     branches: [master]
+  workflow_run:
+    workflows: ["update-fortinet-cvrf"]
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -12,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- run pages workflow after update-fortinet-cvrf completes
- allow manual pages deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Pages deployment is now gated to run only after a related update workflow completes successfully.
  * Prevents deployments from proceeding when the upstream workflow fails, improving site reliability.
  * Enables automatic deployments triggered by completion of the upstream workflow for smoother publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->